### PR TITLE
fixed error where fastq1 basename was applied to a fastq2 output file…

### DIFF
--- a/cfMedipsQc.wdl
+++ b/cfMedipsQc.wdl
@@ -164,7 +164,7 @@ task trimming {
   output {
     File outputFastq1Paired = "~{fastq1Basename}.R1_paired.fastq.gz"
     File outputFastq1Unpaired = "~{fastq1Basename}.R1_unpaired.fastq.gz"
-    File outputFastq2Paired = "~{fastq1Basename}.R2_paired.fastq.gz"
+    File outputFastq2Paired = "~{fastq2Basename}.R2_paired.fastq.gz"
     File outputFastq2Unpaired = "~{fastq2Basename}.R2_unpaired.fastq.gz"
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cfMedipsQc</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
         <workflow-description>Running the medips pipeline</workflow-description>


### PR DESCRIPTION
this is an immediate fix to an error that became apparent when the naming scheme for fastq files was changed

a revision should follow to better manage the new naming scheme as the output files have odd names;  this might wait until we address R1/R2 tagging

output for this is to Dashi, so i suspect odd file names won't be an issue?  