### PR TITLE
Fixing an issue with empty inputs for extractMedipsCounts task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.1.1 - 2022-12-07
+[GDI-2555](https://jira.oicr.on.ca/browse/GDI-2555) : scattering by chromosome also brought in a possibility to encounter empty inputs in shards of extractMedipsCounts task. This is a fix to that.
 # 1.1.0 - 2022-11-20
 [GDI-2615](https://jira.oicr.on.ca/browse/GDI-2615) : scattering the task extractMedipsCounts by chromosome, updated default module for medips script. Additional tasks for handling splitted outputs
 # 1.0.7 - 2022-06-07

--- a/cfMedipsQc.wdl
+++ b/cfMedipsQc.wdl
@@ -550,7 +550,11 @@ task aggregateMetrics {
   }
 }
 
-
+# ===================================================================================
+# This function is meant to be run using scatter. This part of the workflow is split
+# by chromosome to speed up things and lower the requirements for memory. Also, it
+# handles cases with unsufficient data. If there are no data, will return empty files
+# ===================================================================================
 task extractMedipsCounts {
   input {
     File dedupBam
@@ -605,16 +609,26 @@ task extractMedipsCounts {
     fi
  
     set -euo pipefail
-      
-      samtools view -h ~{dedupBam} ~{chromosome}:1-~{chromosomeLength} -b > "~{chromosome}.dedup.bam"
-
+    samtools view -h ~{dedupBam} ~{chromosome}:1-~{chromosomeLength} -b > "~{chromosome}.dedup.bam"
+    READ_COUNT=$(samtools view ~{chromosome}.dedup.bam | wc -l) 
+    
+    if [[ $READ_COUNT == 0 ]]; then
+      touch coverage_windows.txt
+      touch name.txt
+      touch coverage_counts.txt
+      touch enrichment_data.txt
+      touch genome_count.txt
+      touch MEDIPS_window_per_chr.csv
+      touch saturation_metrics.txt
+      touch medips.bed
+    else
       $RSTATS_ROOT/bin/Rscript ~{medips_script} \
         --basedir . \
         --bamfile "~{chromosome}.dedup.bam" \
         --samplename ~{basename} \
         --BSgenome $bsGenome \
         --chromosome ~{chromosome} \
-        --ws  ~{window}\
+        --ws ~{window}\
         --outdir .
       NAME=""
       count0=$(awk '$1 == 0' genome_count.txt | wc -l)
@@ -627,6 +641,7 @@ task extractMedipsCounts {
       echo -e "samples\n~{basename}" > name.txt
       ~{convert2bed} -d --input wig < medips.wig > medips.bed
       rm ~{chromosome}.dedup.bam
+    fi
   >>>
 
   runtime {

--- a/cfMedipsQc.wdl
+++ b/cfMedipsQc.wdl
@@ -84,6 +84,7 @@ workflow cfMedipsQc {
     fastqFormat: "Quality encoding, default is phred33, but can be set to phred64"
     window:  "window length, over which to assess"
     referenceGenome: "reference genome to use"
+    referenceGenomeIndex: ".fai file for the respective ref. genome fasta file"
     referenceModule: "module to load the reference genome"
   }
 

--- a/commands.txt
+++ b/commands.txt
@@ -122,15 +122,26 @@ cfMedipsQC is designed to produce several QC metrics using samtools and picard. 
  
     set -euo pipefail
       
-      samtools view -h ~{dedupBam} ~{chromosome}:1-~{chromosomeLength} -b > "~{chromosome}.dedup.bam"
+    samtools view -h ~{dedupBam} ~{chromosome}:1-~{chromosomeLength} -b > "~{chromosome}.dedup.bam"
+    READ_COUNT=$(samtools view ~{chromosome}.dedup.bam | wc -l)
 
-      $RSTATS_ROOT/bin/Rscript ~{medips_script} \
+    if [[ $READ_COUNT == 0 ]]; then
+      touch coverage_windows.txt
+      touch name.txt
+      touch coverage_counts.txt
+      touch enrichment_data.txt
+      touch genome_count.txt
+      touch MEDIPS_window_per_chr.csv
+      touch saturation_metrics.txt
+      touch medips.bed
+    else
+      Rscript MEDIPS_SCRIPT.R \
         --basedir . \
-        --bamfile "~{chromosome}.dedup.bam" \
-        --samplename ~{basename} \
-        --BSgenome $bsGenome \
-        --chromosome ~{chromosome} \
-        --ws  ~{window}\
+        --bamfile CHROM##.dedup.bam
+        --samplename BASENAME \
+        --BSgenome bsGenome \
+        --chromosome CHROM## \
+        --ws  WINDOW\
         --outdir .
       NAME=""
       count0=$(awk '$1 == 0' genome_count.txt | wc -l)
@@ -142,6 +153,7 @@ cfMedipsQC is designed to produce several QC metrics using samtools and picard. 
       echo -e "$NAME\t$count0\t$count1\t$count10\t$count50\t$count100" >> coverage_windows.txt
       echo -e "samples\n~{basename}" > name.txt
       CONVERT2BED_EXECUTABLE -d --input wig < medips.wig > medips.bed
+    fi
 
 '''
 


### PR DESCRIPTION
I added a block that checks that we have reads in per-chromosome _.bam_ files. If not, extractMedipsCounts task will generate empty file. This change did not require any modifications to external modules, so the deployment of this patch should be quick and easy.